### PR TITLE
Remove mix-manifest.json from index

### DIFF
--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,4 +1,0 @@
-{
-    "/js/app.js": "/js/app.js",
-    "/css/app.css": "/css/app.css"
-}


### PR DESCRIPTION
wasn't removed after added to .gitignore